### PR TITLE
Affichage de la taille du fichier et de la date d'upload en plus de la qualité

### DIFF
--- a/config.txt
+++ b/config.txt
@@ -2,7 +2,7 @@
 # Veuillez ne pas laisser de champs vide sans un "#" en début de ligne 
 # Les champs seront remplis automatiquement si non précisé ici 
 # - ADDRESS : Adresse actuelle du site wawacity. Cette valeur est remplie automatiquement
-# - PATH : Les medias seront téléchargés dans ce dossier 
+# - DOWNLOAD_PATH : Les medias seront téléchargés dans ce dossier 
 # - QUALITY : Qualité par défaut pour télécharger les médias. Lancez une première fois le programme # normalement pour que la valeur soit remplie automatiquement
 # Vous pouvez ajouter une seconde valeur de secours qui sera utilisée si la première n'es pas disponible
 # Les deux valeurs doivent être séparées avec une virgule
@@ -12,13 +12,15 @@
 #       + Methode 2 : Depuis une fenêtre Chrome (Windows uniquement, beaucoup de popups et de pubs)
 # - SKIP_COUNTDOWN : Est-ce que le programme doit déconnecter le PC d'internet pour contourner le # compte a rebours du site 1fichier. Doit être défini par 'OUI' ou 'NON'
 # - CARTE_RES : Le nom de votre carte réseau connectée à internet. Lancez une première fois le # programme normalement pour que la valeur soit remplie automatiquement
+# - CHROME_PATH : (Facultatif) Chemin vers l'exécutable Chrome. Remplir uniquement si Chrome n'est pas trouvé ou pour utiliser une version différente de celle du système  
 #ADDRESS=
-#PATH=
+#DOWNLOAD_PATH=
 #QUALITY=
 #SITE=
 #METHOD=
 #SKIP_COUNTDOWN=
 #CARTE_RES=
+#CHROME_PATH=
 
 # Vous pouvez ici retirer les "#" devant les plateformes que vous payez.
 # Le programme vous préviendra si vous essayez de télécharger un film déjà présent sur l'une de ces plateformes

--- a/config_loader.py
+++ b/config_loader.py
@@ -187,8 +187,8 @@ def build_config() -> None:
         fill_config(tous=True)
 
 
-def fill_config(tous: bool = False, address: str = False, path: str = False, quality: str = False, site: str = False,
-                method: str = False, skip_countdown: str = False, carte_res: str = False, plex: bool = False,
+def fill_config(tous: bool = False, address: str = False, download_path: str = False, quality: str = False, site: str = False,
+                method: str = False, skip_countdown: str = False, chrome_path: str = False, carte_res: str = False, plex: bool = False,
                 manual: bool = True) -> None:
     
     if not isinstance(tous, bool):

--- a/config_loader.py
+++ b/config_loader.py
@@ -91,11 +91,11 @@ def load() -> dict:
 
 
 def verify_config(config: dict) -> dict:
-    if "PATH" in config:
-        if not os.path.exists(config["PATH"].replace("\\", "/")):
-            print(f"{Fore.LIGHTYELLOW_EX}Le chemin spécifié dans config.txt à la valeur \'PATH\' "
+    if "DOWNLOAD_PATH" in config:
+        if not os.path.exists(config["DOWNLOAD_PATH"].replace("\\", "/")):
+            print(f"{Fore.LIGHTYELLOW_EX}Le chemin spécifié dans config.txt à la valeur \'DOWNLOAD_PATH\' "
                   f"n'existe pas{Style.RESET_ALL}\n")
-            config.pop("PATH")
+            config.pop("DOWNLOAD_PATH")
 
     if "SITE" in config:
         if config["SITE"].upper() not in ("1FICHIER", "UPTOBOX DESACTIVE"):     # TODO Enlever ceci
@@ -122,6 +122,13 @@ def verify_config(config: dict) -> dict:
                   f"Il ne peut y avoir que 2 qualité")
             config.pop("QUALITY")
 
+    if "CHROME_PATH" in config:
+        if not os.path.exists(config["CHROME_PATH"].replace("\\", "/")):
+            print(f"{Fore.LIGHTYELLOW_EX}Le chemin spécifié dans config.txt à la valeur \'CHROME_PATH\' "
+                  f"n'existe pas{Style.RESET_ALL}\n")
+            config.pop("CHROME_PATH")
+
+
     return config
     # TODO Verifier que les arguments de config sont bons (quality existe)
 
@@ -135,7 +142,7 @@ def build_config() -> None:
                "# Veuillez ne pas laisser de champs vide sans un \"#\" en début de ligne \n"
                "# Les champs seront remplis automatiquement si non précisé ici \n"
                "# - ADDRESS : Adresse actuelle du site wawacity. Cette valeur est remplie automatiquement\n"
-               "# - PATH : Les medias seront téléchargés dans ce dossier \n"
+               "# - DOWNLOAD_PATH : Les medias seront téléchargés dans ce dossier \n"
                "# - QUALITY : Qualité par défaut pour télécharger les médias. Lancez une première fois le programme "
                "# normalement pour que la valeur soit remplie automatiquement\n"
                "# Vous pouvez ajouter une seconde valeur de secours qui sera utilisée si la première n'es pas disponible\n"
@@ -147,14 +154,17 @@ def build_config() -> None:
                "#       + Methode 2 : Depuis une fenêtre Chrome (Windows uniquement, beaucoup de popups et de pubs)\n"
                "# - SKIP_COUNTDOWN : Est-ce que le programme doit déconnecter le PC d'internet pour contourner le "
                "# compte a rebours du site 1fichier. Doit être défini par \'OUI\' ou \'NON\'\n"
+               "# - CHROME_PATH : (Facultatif) Chemin vers l'exécutable Chrome. "
+               "# Remplir uniquement si le programme Chrome n'est pas trouvé ou pour utiliser une version différente de celle du système \n"
                "# - CARTE_RES : Le nom de votre carte réseau connectée à internet. Lancez une première fois le "
                "# programme normalement pour que la valeur soit remplie automatiquement\n"
                "#ADDRESS=\n"
-               "#PATH=\n"
+               "#DOWNLOAD_PATH=\n"
                "#QUALITY=\n"
                "#SITE=\n"
                "#METHOD=\n"
                "#SKIP_COUNTDOWN=\n"
+               "#CHROME_PATH=\n"
                "#CARTE_RES=\n\n"
                "# Vous pouvez ici retirer les \"#\" devant les plateformes que vous payez. \n"
                "# Le programme vous préviendra si vous essayez de télécharger un film déjà présent sur l'une de ces plateformes\n\n"
@@ -197,9 +207,9 @@ def fill_config(tous: bool = False, address: str = False, path: str = False, qua
     if manual:
         config = load()
     if tous:
-        address, path, quality, site, skip_countdown, carte_res, method, plex = True, True, True, True, True, True, True, True
-    args = {"ADDRESS": address, "PATH": path, "QUALITY": quality, "SITE": site, "METHOD": method,
-            "SKIP_COUNTDOWN": skip_countdown, "CARTE_RES": carte_res, "SERVER_IP": plex, "PORT": plex, "TOKEN": plex}
+        address, download_path, quality, site, skip_countdown, chrome_path, carte_res, method, plex = True, True, True, True, True, True, True, True, True
+    args = {"ADDRESS": address, "DOWNLOAD_PATH": download_path, "QUALITY": quality, "SITE": site, "METHOD": method,
+            "SKIP_COUNTDOWN": skip_countdown, "CHROME_PATH": chrome_path, "CARTE_RES": carte_res, "SERVER_IP": plex, "PORT": plex, "TOKEN": plex}
 
     for i in args:
         if args[i]:

--- a/main.py
+++ b/main.py
@@ -93,8 +93,8 @@ driver = driver_init()
 
 prgm_dir = str(pathlib.Path(__file__).parent.absolute())
 
-if "PATH" in config:
-    dl_dir = config["PATH"]
+if "DOWNLOAD_PATH" in config:
+    dl_dir = config["DOWNLOAD_PATH"]
 else:
     if os.name == "nt":
         dl_dir = pathlib.Path().home() / "Downloads"
@@ -109,12 +109,12 @@ else:
         rep = demande(f"Par défaut, les films seront téléchargés dans le dossier \"{dl_dir}\". "
                       f"Ce chemin vous convient-t-il ?")
 
-    elif "PATH" in config:
+    elif "DOWNLOAD_PATH" in config:
         print(f"\nDossier de téléchargement récupéré dans config.txt : {dl_dir}\n")
         rep = None
 
     else:
-        print("\nLa valeur \"PATH\" est absente de config.txt\n\n")
+        print("\nLa valeur \"DOWNLOAD_PATH\" est absente de config.txt\n\n")
         rep = "NON"
 
 if rep in ("NON", "N"):

--- a/main.py
+++ b/main.py
@@ -132,7 +132,7 @@ if rep in ("NON", "N"):
     rep = demande(f"Voulez vous faire de {dl_dir} la valeur par défaut ?")
 
     if rep in ("OUI", "O"):
-        fill_config(path=dl_dir, manual=False)
+        fill_config(download_path=dl_dir, manual=False)
 
 
 def connect_to_wawacity(link):

--- a/main.py
+++ b/main.py
@@ -164,7 +164,7 @@ except:
           f"Récupération du nouveau lien ...{Fore.BLACK}")
     driver.get("https://www.astuces-aide-informatique.info/17934/nouvelle-adresse-wawacity")
 
-    lien_wawacity = driver.find_element(By.XPATH, "//p/a[contains(@href,\'https://www.wawacity.\')]")
+    lien_wawacity = driver.find_element(By.XPATH, "//p//a[contains(@href,\'https://www.wawacity.\')]")
     lien_wawacity = lien_wawacity.text.removeprefix("https://")
 
     print(f"{Fore.GREEN}Lien trouvé : {lien_wawacity}{Style.RESET_ALL}\n")
@@ -381,7 +381,8 @@ def recup_results(num_page):
 
 print()
 lien_page_film, titre = recup_results(1)
-where_to_watch(titre)
+if "PLATFORMS" in config:
+    where_to_watch(titre)
 
 driver.get(lien_page_film)
 

--- a/recup_lien_1fichier.py
+++ b/recup_lien_1fichier.py
@@ -50,6 +50,9 @@ def driver_init():
     print(f"\n\nInitialising...\n{Fore.BLACK}")
 
     chrome_path = 'Chrome\\App\\Chrome-bin\\chrome.exe'
+    if "CHROME_PATH" in config:
+        chrome_path = config["CHROME_PATH"]
+
     # options = Options()
     service = Service()
     options = webdriver.ChromeOptions()
@@ -60,6 +63,7 @@ def driver_init():
     options.add_argument('--disable-dev-shm-usage')
     options.add_argument('--lang=fr')
     options.add_argument('--disable-extensions')
+    options.add_argument("--disable-search-engine-choice-screen")
     options.binary_location = chrome_path
 
     # service = ChromeService(executable_path=chromedriver_path)

--- a/recup_lien_1fichier.py
+++ b/recup_lien_1fichier.py
@@ -16,7 +16,7 @@ from webdriver_manager.chrome import ChromeDriverManager
 import sys
 
 args = sys.argv
-
+mode_debug = False
 
 if "-d" in args:
     class Fore:
@@ -38,10 +38,11 @@ if "-d" in args:
         LIGHTCYAN_EX = ""
         LIGHTWHITE_EX = ""
 
-
     class Style:
         RESET_ALL = ""
 
+    mode_debug = True
+    
 else:
     from colorama import Fore, Style
 
@@ -58,7 +59,8 @@ def driver_init():
     options = webdriver.ChromeOptions()
 
     options.add_argument(chrome_path)
-    options.add_argument('--headless')
+    if not mode_debug:
+        options.add_argument('--headless')
     options.add_argument('--no-sandbox')
     options.add_argument('--disable-dev-shm-usage')
     options.add_argument('--lang=fr')


### PR DESCRIPTION
Lors de sélection de qualité, il serait préférable de voir, en plus de la qualité:
- la taille du fichier pour éviter les téléchargements trop volumineux ou trop petits (donc de moins bonne qualité
- la date d'upload, car plus l'upload est récent, plus il est probable que les liens soient toujours actifs

Ce PR affiche des informations si le choix de qualité se fait manuellement.